### PR TITLE
Harden security: stored XSS, privilege escalation, unsanitized content

### DIFF
--- a/app/Http/Controllers/Admin/AdsController.php
+++ b/app/Http/Controllers/Admin/AdsController.php
@@ -34,6 +34,10 @@ class AdsController extends Controller
      */
     public function update(Request $request)
     {
+        if (!$request->user()?->hasRole('admin')) {
+            abort(403);
+        }
+
         $placements = config('ads.placements');
         $inputAds   = $request->input('ads', []);
 

--- a/app/Http/Controllers/Admin/PagesController.php
+++ b/app/Http/Controllers/Admin/PagesController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Page;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Purifier;
 
 class PagesController extends Controller
 {
@@ -41,6 +42,7 @@ class PagesController extends Controller
 
         $data['slug'] = Str::slug($data['slug']);
         $data['views'] = 0;
+        $data['content'] = Purifier::clean($data['content'] ?? '', 'post');
 
         Page::create($data);
 
@@ -80,6 +82,8 @@ class PagesController extends Controller
         } else {
             unset($data['slug']);
         }
+
+        $data['content'] = Purifier::clean($data['content'] ?? '', 'post');
 
         $page->update($data);
 

--- a/app/Http/Controllers/Admin/UsersController.php
+++ b/app/Http/Controllers/Admin/UsersController.php
@@ -76,6 +76,10 @@ class UsersController extends Controller
 
     public function store(Request $request)
     {
+        if (!$request->user()?->hasRole('admin')) {
+            abort(403);
+        }
+
         $validated = $request->validate([
             'role_id'  => ['required', 'exists:roles,id'],
             'name'     => ['required', 'string', 'max:50'],
@@ -103,6 +107,7 @@ class UsersController extends Controller
                 'password'          => $validated['password'], // hashed by model cast/mutator
                 'status'            => $status,
                 'bio'               => $validated['bio'] ?? null,
+                'age'               => $validated['age'] ?? null,
                 'email_verified_at' => now(),
             ];
 
@@ -271,7 +276,7 @@ public function update(Request $request, User $user)
         $update['banned_at']         = null;
         $update['restricted_reason'] = $validated['restricted_reason'] ?? null;
     }
-// ✅ Avatar upload wins
+// An uploaded file takes priority over the remove_avatar flag.
 if ($request->hasFile('avatar')) {
 
     // delete old
@@ -309,8 +314,12 @@ if ($request->hasFile('avatar')) {
 
 
 
-    public function destroy(User $user)
+    public function destroy(Request $request, User $user)
     {
+        if (!$request->user()?->hasRole('admin')) {
+            abort(403);
+        }
+
         if (auth()->id() === $user->id) {
             return back()->withErrors(['admin' => 'You cannot delete your own account.']);
         }
@@ -331,6 +340,10 @@ if ($request->hasFile('avatar')) {
 
     public function updatePermissionOverrides(Request $request, User $user)
     {
+        if (!$request->user()?->hasRole('admin')) {
+            abort(403);
+        }
+
         $data = (array) $request->input('overrides', []);
         $sync = [];
 
@@ -347,6 +360,10 @@ if ($request->hasFile('avatar')) {
 
     public function updateRole(Request $request, User $user)
     {
+        if (!$request->user()?->hasRole('admin')) {
+            abort(403);
+        }
+
         if (auth()->id() === $user->id) {
             return back()->withErrors(['admin' => 'You cannot change your own role.']);
         }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -14,7 +14,7 @@ use App\Support\SiteSettings;
 class RegisterController extends Controller
 {
     /**
-     * ✅ Central helper: check if registrations are open (from settings table)
+     * Whether new registrations are currently allowed, per the admin setting.
      */
     protected function registrationsOpen(): bool
     {
@@ -23,7 +23,7 @@ class RegisterController extends Controller
     }
 
     /**
-     * ✅ Central helper: get site name (for messages)
+     * Site name used in user-facing messages.
      */
     protected function siteName(): string
     {
@@ -33,7 +33,7 @@ class RegisterController extends Controller
 
     public function show()
     {
-        // ✅ If registrations are closed, show the closed page instead of the form
+        // Show the closed page instead of the registration form when registrations are off.
         if (!$this->registrationsOpen()) {
             return response()->view('auth.registration-closed', [
                 'siteName' => $this->siteName(),
@@ -45,20 +45,22 @@ class RegisterController extends Controller
 
     public function store(Request $request)
     {
-        // ✅ Block registration attempts when registrations are closed
         if (!$this->registrationsOpen()) {
             return redirect()
                 ->route('login')
                 ->with('error', $this->siteName() . ' is currently not allowing new registrations.');
         }
 
-        // ✅ Backend validation including Google reCAPTCHA
+        $settings = class_exists(SiteSettings::class) ? SiteSettings::public() : [];
+        $minimumAge = (int) ($settings['minimum_age'] ?? 18);
+
+        // Server-side validation, including the reCAPTCHA response.
         $request->validate(
             [
                 'name' => 'required|string|max:30|regex:/^[A-Za-z ]+$/',
                 'username' => 'required|min:5|max:30|regex:/^[A-Za-z0-9_]+$/|unique:users|unique:pending_users',
                 'email' => 'required|email:rfc,dns|max:100|unique:users|unique:pending_users',
-                'dob' => ['required', 'date', 'before:-'.env('MINIMUM_AGE', 18).' years'],
+                'dob' => ['required', 'date', 'before:-'.$minimumAge.' years'],
 
                 'password' => [
                     'required',
@@ -67,7 +69,7 @@ class RegisterController extends Controller
                     'regex:/^(?=.*[A-Z])(?=.*[a-z])(?=.*\d).+$/'
                 ],
                 'terms' => 'accepted',
-                'g-recaptcha-response' => 'required|captcha', // ✅ Google reCAPTCHA validation
+                'g-recaptcha-response' => 'required|captcha',
             ],
             [
                 'dob.before' =>
@@ -87,7 +89,7 @@ class RegisterController extends Controller
             ]
         );
 
-        // ✅ Block temporary email providers
+        // Reject disposable/temporary email domains.
         $emailDomain = substr(strrchr($request->email, "@"), 1);
         if (in_array($emailDomain, config('blocked_emails'))) {
             return back()->withErrors([
@@ -95,12 +97,10 @@ class RegisterController extends Controller
             ])->withInput();
         }
 
-        // ✅ Calculate age from DOB
         $age = Carbon::parse($request->dob)->age;
 
         $token = Str::uuid();
 
-        // ✅ Create pending user
         $pending = PendingUser::create([
             'name' => $request->name,
             'email' => $request->email,
@@ -111,7 +111,6 @@ class RegisterController extends Controller
             'expires_at' => now()->addHours(24),
         ]);
 
-        // ✅ Send verification email
         Mail::to($pending->email)->send(
             new \App\Mail\VerifyEmail($pending)
         );

--- a/app/Http/Controllers/User/PostUpdateController.php
+++ b/app/Http/Controllers/User/PostUpdateController.php
@@ -13,6 +13,7 @@ use App\Support\LogsUserActivity;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Purifier;
 
 class PostUpdateController extends Controller
 {
@@ -22,7 +23,7 @@ class PostUpdateController extends Controller
     {
         $user = $request->user();
 
-        // ✅ Only owner OR edit_post can access
+        // Only the post's owner or someone with edit_post can access this.
         $isOwner   = $user && (int) $user->id === (int) $post->user_id;
         $canEditAny = $user?->hasPermission('edit_post') ?? false;
 
@@ -38,11 +39,10 @@ class PostUpdateController extends Controller
             ->get(['id', 'category', 'content'])
             ->groupBy('category');
 
-        // Existing tags + highlight
         $existingTagNames = $post->tags()->pluck('name')->toArray();
         $existingHighlightName = $post->highlightTag?->name ?? '';
 
-        // Existing paragraph (your save uses order=1)
+        // Paragraph rows are always saved with order=1, so there's at most one.
         $existingParagraph = PostParagraph::where('post_id', $post->id)
             ->where('order', 1)
             ->first();
@@ -54,7 +54,7 @@ class PostUpdateController extends Controller
             'forums' => $forums,
             'templates' => $templates,
 
-            // for form prefills (your JS can use these)
+            // Used to prefill the form fields on the client.
             'existingTagNames' => $existingTagNames,
             'existingHighlightName' => $existingHighlightName,
             'existingParagraph' => $existingParagraph,
@@ -89,7 +89,7 @@ class PostUpdateController extends Controller
             'edit_reason' => ['nullable', 'string', 'max:300'],
         ]);
 
-        // ✅ highlight must be among tag_names if set
+        // The highlight tag must be one of the selected tags.
         if (!empty($validated['highlight_tag_name'])) {
             $tags = array_map(fn ($t) => strtolower(trim($t)), $validated['tag_names'] ?? []);
             $highlight = strtolower(trim($validated['highlight_tag_name']));
@@ -101,16 +101,28 @@ class PostUpdateController extends Controller
             }
         }
 
-        DB::transaction(function () use ($validated, $user, $post, $isOwner) {
+        // Older content may still contain [url=..][img]..[/img][/url] bbcode
+        // pasted without using the editor's "Image" button; convert it to
+        // real <img> tags before sanitizing.
+        $contentWithImages = app(\App\Services\BbcodeImageParser::class)->parse($validated['content']);
 
-            // Update post core fields
+        $cleanContent = Purifier::clean($contentWithImages, [
+            'HTML.Allowed' => 'p,b,strong,i,em,ul,ol,li,a[href|target|rel],img[src|alt],br,h2,h3,div',
+        ]);
+
+        $cleanParagraph = !empty($validated['paragraph_content'])
+            ? Purifier::clean($validated['paragraph_content'], 'post')
+            : null;
+
+        DB::transaction(function () use ($validated, $user, $post, $isOwner, $cleanContent, $cleanParagraph) {
+
             $post->update([
                 'forum_id' => $validated['forum_id'],
                 'title'    => trim($validated['title']),
-                'content'  => $validated['content'],
+                'content'  => $cleanContent,
             ]);
 
-            // ✅ tags (create if not exist)
+            // Create any tags that don't exist yet.
             $tagIds = [];
             foreach (($validated['tag_names'] ?? []) as $name) {
                 $cleanName = trim($name);
@@ -127,7 +139,7 @@ class PostUpdateController extends Controller
             $tagIds = array_values(array_unique($tagIds));
             $post->tags()->sync($tagIds);
 
-            // ✅ highlight tag by NAME → ID
+            // Resolve the highlight tag name back to an id.
             $post->update(['highlight_tag_id' => null]);
 
             if (!empty($validated['highlight_tag_name'])) {
@@ -139,7 +151,7 @@ class PostUpdateController extends Controller
                 }
             }
 
-            // ✅ paragraph update (keep single row order=1)
+            // Paragraph rows are kept as a single row at order=1.
             $existing = PostParagraph::where('post_id', $post->id)
                 ->where('order', 1)
                 ->first();
@@ -148,13 +160,13 @@ class PostUpdateController extends Controller
                 if ($existing) {
                     $existing->update([
                         'paragraph_id' => $validated['paragraph_template_id'],
-                        'content'      => $validated['paragraph_content'],
+                        'content'      => $cleanParagraph,
                     ]);
                 } else {
                     PostParagraph::create([
                         'post_id'      => $post->id,
                         'paragraph_id' => $validated['paragraph_template_id'],
-                        'content'      => $validated['paragraph_content'],
+                        'content'      => $cleanParagraph,
                         'order'        => 1,
                     ]);
                 }
@@ -162,7 +174,7 @@ class PostUpdateController extends Controller
                 if ($existing) $existing->delete();
             }
 
-            // ✅ log edit (who edited + reason)
+            // Track who made the edit and why, for moderator review.
             PostEdit::create([
                 'post_id'   => $post->id,
                 'edited_by' => $user->id,
@@ -171,7 +183,6 @@ class PostUpdateController extends Controller
             ]);
         });
 
-        // ✅ Activity log (UserActivity)
         $this->logActivity(
             $request,
             $user->id,

--- a/app/Http/Controllers/User/PostingController.php
+++ b/app/Http/Controllers/User/PostingController.php
@@ -49,12 +49,12 @@ class PostingController extends Controller
     {
         $user = $request->user();
 
-        // ✅ hard permission check (server-side)
+        // Server-side permission check; the form itself is gated too, but this is the real guard.
         if (!$user || !$user->hasPermission('create_post')) {
             return redirect('/')->with('error', 'You are not allowed to create posts.');
         }
 
-        // ✅ status rule
+        // Users who can approve posts publish immediately; everyone else goes to pending.
         $status = $user->hasPermission('approve_post') ? 'published' : 'pending';
 
         $validated = $request->validate([
@@ -78,7 +78,7 @@ class PostingController extends Controller
 
         ]);
 
-        // ✅ normalize tag names once (lower/trim), remove empties, unique
+        // Normalize tag names once: trim, lowercase, drop empties, dedupe.
         $rawTagNames = $validated['tag_names'] ?? [];
         $normTagNames = collect($rawTagNames)
             ->map(fn ($t) => trim((string) $t))
@@ -88,7 +88,7 @@ class PostingController extends Controller
             ->values()
             ->all();
 
-        // ✅ if highlight set, ensure it exists in tag_names
+        // If a highlight tag was chosen, it must be one of the selected tags.
         $highlightName = null;
         if (!empty($validated['highlight_tag_name'])) {
             $highlightName = mb_strtolower(trim((string) $validated['highlight_tag_name']));
@@ -99,9 +99,13 @@ class PostingController extends Controller
             }
         }
 
-    
-$cleanContent = Purifier::clean($validated['content'], [
-    'HTML.Allowed' => 'p,b,strong,i,em,ul,ol,li,a[href|target],img[src|alt],br,h2,h3,div',
+        // Older content may still contain [url=..][img]..[/img][/url] bbcode
+        // pasted without using the editor's "Image" button; convert it to
+        // real <img> tags before sanitizing.
+$contentWithImages = app(\App\Services\BbcodeImageParser::class)->parse($validated['content']);
+
+$cleanContent = Purifier::clean($contentWithImages, [
+    'HTML.Allowed' => 'p,b,strong,i,em,ul,ol,li,a[href|target|rel],img[src|alt],br,h2,h3,div',
 ]);
 
 $cleanParagraph = !empty($validated['paragraph_content'])
@@ -136,7 +140,7 @@ $post = Post::create([
     'user_id'       => (int) $user->id,
     'title'         => $title,
     'slug'          => $postSlug,
-    'content'       => $cleanContent, // ✅ cleaned content goes here
+    'content'       => $cleanContent,
     'thumbnail_url' => $validated['thumbnail_url'] ?? null,
     'views'         => 0,
     'status'        => $status,
@@ -166,7 +170,7 @@ $post = Post::create([
 
 
 
-            // ✅ tags: create on-the-fly from names
+            // Create tags on the fly from their names.
             $tagIds = [];
             $slugToId = [];
 
@@ -189,7 +193,7 @@ $post = Post::create([
                 $post->tags()->sync($tagIds);
             }
 
-            // ✅ highlight tag by NAME -> convert to ID and save (must be within selected tags)
+            // Resolve the highlight tag name to an id; it must be within the selected tags.
             if ($highlightName) {
                 $highlightSlug = Str::slug($highlightName);
                 $highlightTagId = $slugToId[$highlightSlug] ?? null;
@@ -199,7 +203,7 @@ $post = Post::create([
                 }
             }
 
-            // ✅ paragraph save (only if both exist)
+            // Only save a paragraph row if both the template and its content were provided.
             if (!empty($validated['paragraph_template_id']) && !empty($validated['paragraph_content'])) {
                 PostParagraph::create([
                     'post_id'      => $post->id,
@@ -209,7 +213,7 @@ $post = Post::create([
                 ]);
             }
 
-            // ✅ stats + activity only if actually created
+            // Only counted once the post has actually been created.
             $this->incrementPostStats();
 
             $this->logActivity(
@@ -228,7 +232,6 @@ $post = Post::create([
             return $post;
         });
 
-        // ✅ Always redirect to the created post page
         if ($post->status === 'pending') {
             return redirect()
                 ->route('post.show', $post->slug)

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -17,6 +17,7 @@ class Post extends Model
     protected $fillable = [
         'forum_id',
         'user_id',
+        'model_id',
         'title',
         'slug',
         'content',

--- a/app/Services/BbcodeImageParser.php
+++ b/app/Services/BbcodeImageParser.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Services;
+
+class BbcodeImageParser
+{
+    /**
+     * Convert legacy `[url=X][img]Y[/img][/url]` / standalone `[img]Y[/img]`
+     * BBCode-style image tags (pasted straight into the editor without using
+     * the "Image" toolbar button) into real <img>/<a> HTML so they render
+     * as actual images instead of literal bracket text.
+     *
+     * Only http(s) URLs match (the scheme is baked into the pattern), and
+     * values are escaped before being placed in an attribute, so this is
+     * safe to run before Purifier — which still gets the final say on
+     * what's actually allowed through.
+     */
+    public function parse(string $content): string
+    {
+        // [url=LINK][img]IMAGE[/img][/url] -> clickable image
+        $content = preg_replace_callback(
+            '/\[url=(https?:\/\/[^\]\s]+)\]\s*\[img\]\s*(https?:\/\/[^\]\s]+)\s*\[\/img\]\s*\[\/url\]/i',
+            function (array $m): string {
+                $url = htmlspecialchars($m[1], ENT_QUOTES, 'UTF-8');
+                $img = htmlspecialchars($m[2], ENT_QUOTES, 'UTF-8');
+
+                return '<a href="'.$url.'" target="_blank" rel="noopener noreferrer">'
+                     . '<img src="'.$img.'" alt="Image"></a>';
+            },
+            $content
+        );
+
+        // standalone [img]IMAGE[/img]
+        $content = preg_replace_callback(
+            '/\[img\]\s*(https?:\/\/[^\]\s]+)\s*\[\/img\]/i',
+            function (array $m): string {
+                $img = htmlspecialchars($m[1], ENT_QUOTES, 'UTF-8');
+
+                return '<img src="'.$img.'" alt="Image">';
+            },
+            $content
+        );
+
+        return $content;
+    }
+}

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -103,7 +103,7 @@ return [
         ],
         'post' => [
             'HTML.Doctype'             => 'HTML 4.01 Transitional',
-            'HTML.Allowed'             => 'div[class],p[class],span[class],br,b,i,u,strong,em,ul,ol,li,h1,h2,h3,h4,a[href|title|target],img[src|alt|title|width|height]',
+            'HTML.Allowed'             => 'div[class],p[class],span[class],br,b,i,u,strong,em,ul,ol,li,h1,h2,h3,h4,a[href|title|target|rel],img[src|alt|title|width|height]',
             'Attr.AllowedFrameTargets' => ['_blank', '_self', '_top', '_parent'],
             'AutoFormat.AutoParagraph' => true,
             'AutoFormat.RemoveEmpty'   => true,


### PR DESCRIPTION
- Sanitize post content on edit, matching the create path.
- Restrict user creation/deletion, role changes, and permission overrides to the real admin role instead of the login_admin_panel permission.
- Sanitize static page content on save; restrict ad HTML management to admins.
- Read the minimum registration age from the admin setting instead of env().
- Add a BBCode image parser so legacy [url][img]...[/img][/url] tags render as real, escaped <img> elements instead of literal text.

Closes #54