### PR TITLE
Fix pagination bugs and add missing indexes/caching

### DIFF
--- a/app/Http/Controllers/Public/ForumController.php
+++ b/app/Http/Controllers/Public/ForumController.php
@@ -34,7 +34,7 @@ class ForumController extends Controller
                 },
             ])
             ->orderBy('name')
-            ->paginate(1);
+            ->paginate(20);
 
         return view('forums.index', compact('forums'));
     }
@@ -45,7 +45,7 @@ class ForumController extends Controller
 
         $sort = $request->query('sort', 'recent');
         $perPage = 9;
-        $page = $request->query('page', 1); // ✅ use query param, not route param
+        $page = $request->query('page', 1); // Read from the query string, not a route parameter.
 
         // 1) Get pinned posts (newest pin first)
         $pinned = Post::query()
@@ -132,7 +132,7 @@ class ForumController extends Controller
             $page,
             [
                 'path' => url('/forum/' . $forum->slug),
-                'query' => $request->query(), // ✅ keeps ?sort=recent/page=2
+                'query' => $request->query(), // Preserves ?sort=recent&page=2 in pagination links.
             ]
         );
 

--- a/app/Http/Controllers/Public/SearchController.php
+++ b/app/Http/Controllers/Public/SearchController.php
@@ -14,7 +14,7 @@ use Illuminate\View\View;
 
 class SearchController extends Controller
 {
-    private const PER_PAGE = 1;
+    private const PER_PAGE = 10;
     private const MIN_QUERY_LEN = 2;
     private const MAX_QUERY_LEN = 120;
 

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 
 class Setting extends Model
 {
@@ -12,7 +13,13 @@ class Setting extends Model
 
     public static function get(string $key, $default = null)
     {
-        return static::where('key', $key)->value('value') ?? $default;
+        $value = Cache::remember(
+            "setting.{$key}",
+            300,
+            fn () => static::where('key', $key)->value('value')
+        );
+
+        return $value ?? $default;
     }
 
     public static function set(string $key, $value): void
@@ -21,5 +28,7 @@ class Setting extends Model
             ['key' => $key],
             ['value' => (string) $value]
         );
+
+        Cache::forget("setting.{$key}");
     }
 }

--- a/database/migrations/2026_07_08_000002_add_performance_indexes.php
+++ b/database/migrations/2026_07_08_000002_add_performance_indexes.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->index('status');
+            $table->index(['status', 'created_at']);
+        });
+
+        Schema::table('page_views', function (Blueprint $table) {
+            $table->index('created_at');
+            $table->index('is_guest');
+        });
+
+        // `path` is a VARCHAR(2048); a full-column index would exceed MySQL's
+        // InnoDB key-length limit under utf8mb4, so index a prefix instead.
+        if (Schema::getConnection()->getDriverName() === 'mysql') {
+            DB::statement('ALTER TABLE page_views ADD INDEX page_views_path_index (path(191))');
+        } else {
+            Schema::table('page_views', function (Blueprint $table) {
+                $table->index('path');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex(['status']);
+            $table->dropIndex(['status', 'created_at']);
+        });
+
+        Schema::table('page_views', function (Blueprint $table) {
+            $table->dropIndex(['created_at']);
+            $table->dropIndex(['is_guest']);
+            $table->dropIndex(['path']);
+        });
+    }
+};


### PR DESCRIPTION
- Fix search and forum listing both being hardcoded to paginate(1).
- Add indexes on posts.status and page_views columns used in admin queries.
- Cache site settings lookups instead of re-querying on every request.

Closes #58